### PR TITLE
[BUG:LONGPRESS] fix sensitivity issue on samsung s4 devices when using longpress

### DIFF
--- a/src/pl/polidea/gesturedetector/BetterGestureDetector.java
+++ b/src/pl/polidea/gesturedetector/BetterGestureDetector.java
@@ -251,9 +251,7 @@ public class BetterGestureDetector {
     public void onTouchEvent(final MotionEvent motionEvent) {
         float dx = motionEvent.getX() - prevTouchX;
         float dy = motionEvent.getY() - prevTouchY;
-        long dt = System.currentTimeMillis() - prevTouchTime;
-        handler.removeCallbacks(longPressHandler);
-        longPressHandler = null;
+        long dt = System.currentTimeMillis() - prevTouchTime;        
 
         switch (motionEvent.getAction()) {
         case MotionEvent.ACTION_DOWN:
@@ -278,7 +276,7 @@ public class BetterGestureDetector {
 
             };
             handler.postDelayed(pressHandler, pressTimeout);
-
+            handler.removeCallbacks(longPressHandler);
             longPressHandler = new Runnable() {
 
                 @Override


### PR DESCRIPTION
On Samsung S4 the long press event is not fired. 
The problem is that ACTION_MOVE is called in between ACTION_DOWN AND ACTION_RELEASE  even though the finger is not moved on the screen.
This is happening only on Samsung devices, as I could tested so far and I believe is because screen sensitivity on samsung is higher than other devices.
